### PR TITLE
Initialize Timber correctly

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -4,7 +4,7 @@ ini_set('display_errors', TRUE);
 ini_set('display_startup_errors', TRUE);
 require_once __DIR__ . '/vendor/autoload.php';
 
-use Timber;
+$timber = new \Timber\Timber();
 class StarterSite extends Timber\Site {
 
 	function __construct() {


### PR DESCRIPTION
First of all thanks for the great starter theme, it helped me get started with Timber!

By using `use Timber` you get the following PHP warning:
`Warning: The use statement with non-compound name 'Timber' has no effect in /app/public/wp-content/themes/your-theme-name/functions.php on line 7`

It also causes problems with some of the Timber functionalities. For example ACF Flexible content fields do not work. I guess there are more stuff that doesn't work either.

It can be simply fixed by initializing Timber like instructed in their repo:
`$timber = new \Timber\Timber();`