### PR TITLE
404 template not found

### DIFF
--- a/404.php
+++ b/404.php
@@ -11,4 +11,4 @@
 use Timber\Timber;
 
 $context = Timber::get_context();
-Timber::render('404.twig', $context);
+Timber::render(array('pages/404.twig'), $context);


### PR DESCRIPTION
File 404.php was missing pages folder from the template path and it caused an error. 
Also added it as an array like on other templates.